### PR TITLE
Allow user to specify the configuration explicitely.

### DIFF
--- a/src/main/java/tec/units/tck/TCKSetup.java
+++ b/src/main/java/tec/units/tck/TCKSetup.java
@@ -29,6 +29,7 @@
  */
 package tec.units.tck;
 
+import java.util.Objects;
 import java.util.ServiceLoader;
 
 import javax.inject.Singleton;
@@ -44,24 +45,24 @@ import tec.units.tck.util.ServiceConfiguration;
 @Singleton
 public final class TCKSetup {
 
-	private static ServiceConfiguration TEST_CONFIG = loadConfiguration();
+    private static ServiceConfiguration testConfig;
 
-	private TCKSetup() {
-	}
+    private TCKSetup() {
+    }
 
-	private static ServiceConfiguration loadConfiguration() {
-		try {
-			return ServiceLoader.load(ServiceConfiguration.class).iterator()
-					.next();
-		} catch (Exception e) {
-			throw new IllegalStateException("No valid implementation of "
-						+ ServiceConfiguration.class.getName()
-						+ " is registered with the ServiceLoader.");
-		}
-	}
+    public static synchronized ServiceConfiguration getConfiguration() {
+        if (testConfig == null) try {
+            testConfig = ServiceLoader.load(ServiceConfiguration.class).iterator()
+                    .next();
+        } catch (Exception e) {
+            throw new IllegalStateException("No valid implementation of "
+                        + ServiceConfiguration.class.getName()
+                        + " is registered with the ServiceLoader.");
+        }
+        return testConfig;
+    }
 
-	public static final ServiceConfiguration getConfiguration() {
-		return TEST_CONFIG;
-	}
-
+    public static synchronized void setConfiguration(ServiceConfiguration config) {
+        testConfig = Objects.requireNonNull(config);
+    }
 }


### PR DESCRIPTION
The intent is to allow execution of tests in the same Maven project than the implementation, instead to create a separated Maven project. We can not always use the `ServiceProvider` in such case because we don't want to add a `provides` clause in `module-info.java` of the main code, and I have not yet found a way to add a `provides` clause in test code only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-tck/32)
<!-- Reviewable:end -->
