### PR TITLE
Allow developers to specify the configuration programmatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ JSR 385 Technology Compatibility Kit (TCK)
 [![License](http://img.shields.io/badge/license-BSD3-blue.svg?style=flat-square)](http://opensource.org/licenses/BSD-3-Clause)
 
 The current module contains the technology compatibility kit of JSR 385.
+The tests can be executed either as a separated project,
+or integrated with the test suite of the implementation.
+
+
+# Test in a separated Maven project
 
 To setup the TCK with your implementation you must follow the following steps:
 
@@ -66,3 +71,36 @@ To override the default TCK report file
 -Dtech.units.tck.verbose=true/false
 ```
 To toggle the `verbose` option of the TCK for extended test output. The default is `false`. And you normally won't need to set this unless you require detailed analysis or issue resolution.
+
+
+# Integrate with implementation tests
+
+For running the TCK as part of an implementation build process,
+it may not be convenient to use the `ServiceLoader` mechanism.
+For example it is not always easy to amend the project `module-info`
+with a `provides tech.units.tck.…` clause only during the tests.
+Instead, the class implementing the `tech.units.tck.util.ServiceConfiguration` interface
+can be declared by a call to `TCKSetup.initialize(ServiceConfiguration)`.
+Steps are:
+
+1. Add this TCK as a project dependency with `<scope>test</scope>`.
+2. Add a test class implementing `tech.units.tck.util.ServiceConfiguration`.
+3. Add a test method like below:
+
+```java
+import tech.units.tck.TCKSetup;
+import tech.units.tck.TCKRunner;
+
+public class MyTest implements ServiceConfiguration {
+    @Test
+    public void runTCK() {
+        TCKSetup.initialize(this);
+        final TCKRunner runner = new TCKRunner();
+        int result = runner.run(System.in, System.out, System.err);
+        assertEquals("Some TCK tests failed.", 0, result);
+    }
+}
+```
+
+After above steps, the TCK become part of the project test suite
+and is run every time that the project is built.

--- a/docs/index.html
+++ b/docs/index.html
@@ -94,14 +94,37 @@
             <p>JSR 385 - Technology Compatibility Kit (TCK)</p>
 <p><img src="img/240px-Logo_TCK.png" alt="alt text" title="TCK" /></p>
 
-<p>This module contains the <a href="https://github.com/unitsofmeasurement/unit-tck" target="_top">technology compatibility kit of JSR 385</a>.</p>
-<p>To setup the TCK with your implementation you must follow the following steps:</p>
+<p>This module contains the <a href="https://github.com/unitsofmeasurement/unit-tck" target="_top">technology compatibility kit of JSR 385</a>.
+The tests can be executed either as a separated project, or integrated with the test suite of the implementation.</p>
+<p>To setup the TCK as a separated Maven project for testing your implementation, you can follow the following steps:</p>
 <ol>
 <li>Create a new Maven project. You could also use compatible alternatives like Gradle.</li>
 <li>Add this TCK and your implementation as dependency.</li>
 <li>Implement a class of type tech.units.tck.util.ServiceConfiguration, read the Javadoc, what
 you must provide with this class.</li>
 </ol>
+<p>Alternatively, for running the TCK as part of an implementation build process, the following steps can be used.
+Those tests avoid the needs to put a <code>provides tech.units.tck.util.ServiceConfiguration</code> statement in
+the project <code>module-info</code> file:</p>
+<ol>
+<li>Add this TCK as a project dependency with <code>&lt;scope&gt;test&lt;/scope>&gt;</code>.</li>
+<li>Add a test class implementing <code>tech.units.tck.util.ServiceConfiguration</code>.</li>
+<li>Add a test method like below:
+<pre>import tech.units.tck.TCKSetup;
+import tech.units.tck.TCKRunner;
+
+public class MyTest implements ServiceConfiguration {
+    @Test
+    public void runTCK() {
+        TCKSetup.initialize(this);
+        final TCKRunner runner = new TCKRunner();
+        int result = runner.run(System.in, System.out, System.err);
+        assertEquals("Some TCK tests failed.", 0, result);
+    }
+}</pre></li>
+</ol>
+<p>After above steps, the TCK become part of the project test suite and is run every time that the project is built.</p>
+
 <h2><a id="user-content-running" class="anchor" aria-hidden="true" href="#running"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Running</h2>
 <p>To run the TCK, simply execute</p>
 <pre><code>mvn clean test


### PR DESCRIPTION
The intent is to allow execution of tests in the same Maven project than the implementation, instead of creating a separated Maven project. We can not always use the `ServiceProvider` mechanism because we may not want to add a `provides` clause in `module-info.java` of the main code.

This is the same goal than #32 but coded differently. Despite being labelled as "merged", #32 does not appears in the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-tck/43)
<!-- Reviewable:end -->
