### PR TITLE
Comparison of Quantity.getValue() should not depend on the number class

### DIFF
--- a/src/main/java/tech/units/tck/tests/spi/ObtainingQuantiesTest.java
+++ b/src/main/java/tech/units/tck/tests/spi/ObtainingQuantiesTest.java
@@ -63,7 +63,7 @@ import tech.units.tck.util.TestUtils;
 @SpecVersion(spec = SPEC_ID, version = SPEC_VERSION)
 public class ObtainingQuantiesTest {
     private static final String SECTION_NUM = "5.6.1";
-    
+
     // ************************ 5.6 Obtaining Quantity Instances
     // ************************
     /**
@@ -110,7 +110,7 @@ public class ObtainingQuantiesTest {
             TestUtils.testHasPublicMethod(SECTION_PREFIX + SECTION_NUM, factory.getClass(), Unit.class, "getSystemUnit");
         }
     }
-    
+
     /**
      * Try parsing a quantity string for each registered unit.
      * @since 2.1
@@ -132,7 +132,7 @@ public class ObtainingQuantiesTest {
 //				    System.out.println("S " + i + ": " + s + "(" + u.getSymbol() + ")");
 				    Quantity q = format.parse("1 " + s);
 				    assertEquals(SECTION_PREFIX + SECTION_NUM + ": Quantity unit could not be parsed for '" + s + "'", u, q.getUnit());
-				    assertEquals(SECTION_PREFIX + SECTION_NUM + ": Quantity value could not be parsed for '" + s + "'", 1, q.getValue());
+				    assertEquals(SECTION_PREFIX + SECTION_NUM + ": Quantity value could not be parsed for '" + s + "'", 1, q.getValue().doubleValue(), 0);
 //				    i++;
 				}
 		    }


### PR DESCRIPTION
Before this change, running the TCK on Seshat caused the following failure:

```
[FAILED]  5.6.1 Quantities obtained by string parsing(ObtainingQuantiesTest#testGetQuantitiesFromString):
java.lang.AssertionError: Section 5.6.1: Quantity value could not be parsed for '' expected:<1> but was:<1>
```

Note the "expected:<1> but was:<1>" part of the message. It was caused by TCK expecting 1 as a `java.lang.Integer` while Seshat provides 1 as a `java.lang.Double`. This commit compares the `double` value, which makes the test independent of the actual number class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-tck/45)
<!-- Reviewable:end -->
